### PR TITLE
feat(#3): Derive FromStr for OpCode using strum dependency

### DIFF
--- a/do-core/src/instruction.rs
+++ b/do-core/src/instruction.rs
@@ -21,6 +21,19 @@ impl OpCode {
     }
 }
 
+impl std::str::FromStr for OpCode {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LD"  => Ok(OpCode::LD),
+            "ST"  => Ok(OpCode::ST),
+            "ADD" => Ok(OpCode::ADD),
+            "XOR" => Ok(OpCode::XOR),
+            _ =>     Err(Error::ParseOpError),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Instruction {
     opcode: OpCode,
@@ -61,8 +74,10 @@ impl Instruction {
 
 #[cfg(test)]
 mod tests {
-    use crate::instruction::{Instruction, OpCode};
+    use super::*;
     use crate::Error;
+    
+    use std::str::FromStr;
 
     #[test]
     fn test_instruction_disassemble_add_r0_r1() -> Result<(), Error> {
@@ -137,6 +152,16 @@ mod tests {
         assert_eq!(insn.op0, 5);
         assert_eq!(insn.op1, 0);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_opcode_from_string() -> Result<(), Error> {
+        assert_eq!(OpCode::from_str("ADD").unwrap(), OpCode::ADD);
+        assert_eq!(OpCode::from_str("LD").unwrap(), OpCode::LD);
+
+        assert!(OpCode::from_str("GIBBERISH").is_err());
+        
         Ok(())
     }
 }

--- a/do-core/src/instruction.rs
+++ b/do-core/src/instruction.rs
@@ -25,11 +25,11 @@ impl std::str::FromStr for OpCode {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "LD"  => Ok(OpCode::LD),
-            "ST"  => Ok(OpCode::ST),
+            "LD" => Ok(OpCode::LD),
+            "ST" => Ok(OpCode::ST),
             "ADD" => Ok(OpCode::ADD),
             "XOR" => Ok(OpCode::XOR),
-            _ =>     Err(Error::ParseOpError),
+            _ => Err(Error::ParseOpError),
         }
     }
 }
@@ -76,7 +76,7 @@ impl Instruction {
 mod tests {
     use super::*;
     use crate::Error;
-    
+
     use std::str::FromStr;
 
     #[test]
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(OpCode::from_str("LD").unwrap(), OpCode::LD);
 
         assert!(OpCode::from_str("GIBBERISH").is_err());
-        
+
         Ok(())
     }
 }

--- a/do-core/src/lib.rs
+++ b/do-core/src/lib.rs
@@ -8,6 +8,7 @@ pub enum Error {
     Op1OutOfRange,
     AdditionOverflow(u16, u16),
     MemoryOverflow(u16),
+    ParseOpError,
 }
 
 // do-core register indexes range from 0 to 7.


### PR DESCRIPTION
This will allow my assembler to depend on do-core for its OpCode parsing

I added a dependency to strum and strum_macros to automatically generate the FromStr implementation, which doesn't introduce any overhead to adding new opcodes.

